### PR TITLE
ignore querystring parameter whenever an error occurs 

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -1,6 +1,6 @@
-var express = require('express')
-  , partialResponse = require('../')
-  , app = express()
+const express = require('express'), 
+      partialResponse = require('../'), 
+      app = express()
 
 app.use(partialResponse())
 
@@ -15,7 +15,20 @@ app.get('/', function (res, res, next) {
           firstName: 'Bapu'
       }]
   })
-})
+});
+
+app.get('/error', (req, res, next) => {
+    next(new Error("oops something went wrong"));    
+});
+
+app.use((err, req, res, next) => {
+   res.status(500).json({
+      error: err.message,
+      code: res.statusCode 
+   });
+
+   next();
+});
 
 app.listen(4000, function () {
   var prefix = 'curl \'http://localhost:4000?fields=%s\''

--- a/index.js
+++ b/index.js
@@ -1,25 +1,24 @@
-var jsonMask = require('json-mask'),
-  compile = jsonMask.compile,
-  filter = jsonMask.filter;
+const { compile, filter } = require('json-mask');
 
 module.exports = function (opt) {
   opt = opt || {};
 
-  function partialResponse(obj, fields) {
-    if (!fields) return obj;
+  function partialResponse (obj, fields) {
+    if (!fields || this.statusCode !== 200) return obj;
     return filter(obj, compile(fields));
   }
 
-  function wrap(orig) {
+  function wrap (orig) {
+    
     return function (obj) {
-      var param = this.req.query[opt.query || 'fields'];
+      let param = this.req.query[opt.query || 'fields'];
       if (1 === arguments.length) {
-        orig(partialResponse(obj, param));
+        orig(partialResponse.call(this, obj, param));
       } else if (2 === arguments.length) {
         if ('number' === typeof arguments[1]) {
-          orig(arguments[1], partialResponse(obj, param));
+          orig(arguments[1], partialResponse.call(this, obj, param));
         } else {
-          orig(obj, partialResponse(arguments[1], param));
+          orig(obj, partialResponse.call(this, arguments[1], param));
         }
       }
     };


### PR DESCRIPTION
Whenever an error occurs and the querystring parameter is set, it filters the json result and doesn't return an error message.